### PR TITLE
Build script improvements and reverting "Remove .NET Framework support" due to VS project system bug

### DIFF
--- a/DjvuNet.DjvuLibre.Helper.Tests/DjvuNet.DjvuLibre.Helper.Tests.csproj
+++ b/DjvuNet.DjvuLibre.Helper.Tests/DjvuNet.DjvuLibre.Helper.Tests.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonSoftJsonPackageVersion)" />
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="xunit.extensibility.core" Version="$(XunitPackageVersion)" />
     <PackageReference Include="xunit.extensibility.execution" Version="$(XunitPackageVersion)" />
@@ -50,7 +51,7 @@
     <ProjectReference Include="$(RepoRootDir)System.Attributes\System.Attributes.csproj" />
   </ItemGroup>
 
-  <Import Project="$(RepoRootDir)DjvuNet.Shared.Tests\DjvuNet.Shared.Tests.projitems" />
+  <Import Project="$(RepoRootDir)DjvuNet.Shared.Tests\DjvuNet.Shared.Tests.props" />
   <ItemGroup>
     <Compile Remove="$(RepoRootDir)DjvuNet.Shared.Tests\DjvuDocumentUtil.cs" />
   </ItemGroup>

--- a/DjvuNet.Shared.Tests/DjvuNet.Shared.Tests.props
+++ b/DjvuNet.Shared.Tests/DjvuNet.Shared.Tests.props
@@ -42,9 +42,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestExecution\TestManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Util.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UtilJson.cs" />
-    <Compile Condition="$(TargetFramework) == 'net472'" Include="$(MSBuildThisFileDirectory)UtilRoot.cs" />
-    <Compile Condition="$(TargetFramework) == 'netstandard2.1'" Include="$(MSBuildThisFileDirectory)UtilRoot.netstandard2.1.cs" />
-    <Compile Condition="$(TargetFramework) == 'netcoreapp3.0'" Include="$(MSBuildThisFileDirectory)UtilRoot.netcoreapp3.0.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UtilRoot.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)xunit\DjvuDataRowTestCase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)xunit\DjvuNamedDataRowTestCase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)xunit\DjvuTheoryAttribute.cs" />

--- a/DjvuNet.Tests/DjvuNet.Tests.csproj
+++ b/DjvuNet.Tests/DjvuNet.Tests.csproj
@@ -122,6 +122,7 @@
     <PackageReference Include="xunit.extensibility.execution" Version="$(XunitPackageVersion)" />
     <PackageReference Include="xunit.runner.console" Version="$(XunitPackageVersion)" >
       <CopyToOutputDirectory Condition="$(TargetFramework) == $(DotNetCoreFrameworkVersion)">tools/netcoreapp2.0/*.*</CopyToOutputDirectory>
+      <!--<CopyToOutputDirectory Condition="$(TargetFramework) == $(NetFXTargetFrameworkVersion)">tools/$(NetFXTargetFrameworkVersion)/*.*</CopyToOutputDirectory>-->
     </PackageReference>
     <PackageReference Include="xunit.console" Version="$(XunitPackageVersion)" >
       <CopyToOutputDirectory Condition="$(TargetFramework) == $(DotNetCoreFrameworkVersion)">tools/netcoreapp2.0/*.*</CopyToOutputDirectory>

--- a/DjvuNetBuild.props
+++ b/DjvuNetBuild.props
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <NetFXTargetFrameworkVersion>net472</NetFXTargetFrameworkVersion>
     <DotNetCoreFrameworkVersion>netcoreapp3.0</DotNetCoreFrameworkVersion>
     <DotNetStandardVersion>netstandard2.1</DotNetStandardVersion>
   </PropertyGroup>
@@ -168,6 +169,11 @@
     <PlatformTarget>Arm64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == $(NetFXTargetFrameworkVersion)">
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfoCommon.cs" />
+  </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) != $(NetFXTargetFrameworkVersion)">
     <Compile Include="Properties\AssemblyInfo.$(TargetFramework).cs" />

--- a/DjvuNetBuild.targets
+++ b/DjvuNetBuild.targets
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <IntermediateOutputPath>$(MSBuildThisFileDirectory)/build/bin/$(OS).$(Platform).$(Configuration)/obj/$(AssemblyName)/</IntermediateOutputPath>
     <DefineConstants Condition="$(APPVEYOR) == 'True'">_APPVEYOR;$(DefineConstans)</DefineConstants>
-    <GitTasksAssembly Condition="$(GitTasksAssembly) == ''">$(MSBuildThisFileDirectory)Tools/DjvuNet/$(DotNetCoreFrameworkVersion)/DjvuNet.Git.Tasks.dll</GitTasksAssembly>
+    <GitTasksAssembly Condition="$(GitTasksAssembly) == '' And '$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)Tools/DjvuNet/$(DotNetCoreFrameworkVersion)/DjvuNet.Git.Tasks.dll</GitTasksAssembly>
+    <GitTasksAssembly Condition="$(GitTasksAssembly) == '' And '$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)Tools/DjvuNet/$(NetFXTargetFrameworkVersion)/DjvuNet.Git.Tasks.dll</GitTasksAssembly>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -55,15 +56,25 @@
     <Message Importance="High"
              Text="Building [$(TargetName)] target framework: [$(TargetFramework)], assembly version: [$(DjvuAssemblyVersion)], file version: [$(FullBuildVersion)], configuration: [$(Configuration)], platform [$(Platform)], branch: [$(BuildBranch)] commit: [$(CommitVersion)]"/>
 
-    <Copy Condition="$(TargetFramework) != ''" SourceFiles="$(ProjectDir)Properties/AssemblyInfo.Template.cs"
+    <Copy Condition="$(TargetFramework) == 'net472'" SourceFiles="$(ProjectDir)Properties/AssemblyInfo.Template.cs"
+          DestinationFiles="$(ProjectDir)Properties/AssemblyInfo.cs"/>
+    <Copy Condition="$(TargetFramework) == 'net472'" SourceFiles="$(MSBuildThisFileDirectory)Templates/AssemblyInfoCommon.Template.cs"
+          DestinationFiles="$(ProjectDir)Properties/AssemblyInfoCommon.cs"/>
+
+    <Copy Condition="$(TargetFramework) != 'net472'" SourceFiles="$(ProjectDir)Properties/AssemblyInfo.Template.cs"
       DestinationFiles="$(ProjectDir)Properties/AssemblyInfo.$(TargetFramework).cs"/>
-    <Copy Condition="$(TargetFramework) != ''" SourceFiles="$(MSBuildThisFileDirectory)Templates/AssemblyInfoCommon.Template.cs"
+    <Copy Condition="$(TargetFramework) != 'net472'" SourceFiles="$(MSBuildThisFileDirectory)Templates/AssemblyInfoCommon.Template.cs"
           DestinationFiles="$(ProjectDir)Properties/AssemblyInfoCommon.$(TargetFramework).cs"/>
 
     <Copy SourceFiles="$(MSBuildThisFileDirectory)Templates/UtilRoot.Template.cs" Condition="$(UtilRepoRootUpdate) == true"
           DestinationFiles="$(ProjectDir)../DjvuNet.Shared.Tests/UtilRoot.cs"/>
 
-    <ItemGroup Condition="$(TargetFramework) != ''">
+    <ItemGroup Condition="$(TargetFramework) == 'net472'">
+      <WriteFiles Include='$(ProjectDir)Properties/AssemblyInfo.cs' />
+      <WriteFiles Include='$(ProjectDir)Properties/AssemblyInfoCommon.cs' />
+    </ItemGroup>
+
+    <ItemGroup Condition="$(TargetFramework) != 'net472'">
       <WriteFiles Include='$(ProjectDir)Properties/AssemblyInfo.$(TargetFramework).cs' />
       <WriteFiles Include='$(ProjectDir)Properties/AssemblyInfoCommon.$(TargetFramework).cs' />
     </ItemGroup>

--- a/build/tools/DjvuNet.Git.Tasks.Tests/DjvuNet.Git.Tasks.Tests.csproj
+++ b/build/tools/DjvuNet.Git.Tasks.Tests/DjvuNet.Git.Tasks.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), DjvuNetBuild.props))\DjvuNetBuild.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>$(DotNetCoreFrameworkVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFXTargetFrameworkVersion);$(DotNetCoreFrameworkVersion)</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DjvuNet.Git.Tasks.Tests</RootNamespace>

--- a/build/tools/DjvuNet.Git.Tasks/DjvuNet.Git.Tasks.csproj
+++ b/build/tools/DjvuNet.Git.Tasks/DjvuNet.Git.Tasks.csproj
@@ -10,7 +10,7 @@
     <IsTool>true</IsTool>
     <Title>$(PackageId) - DjvuNet custom build tool</Title>
     <Description>$(PackageId) implements custom MSBuild build tasks used in DjvuNet repository build infrastructure.</Description>
-    <TargetFrameworks>$(DotNetCoreFrameworkVersion)</TargetFrameworks>
+    <TargetFrameworks>$(DotNetCoreFrameworkVersion);$(NetFXTargetFrameworkVersion)</TargetFrameworks>
     <NETStandardImplicitPackageVersion>$(NETStandardPackageVersion)</NETStandardImplicitPackageVersion>
     <!--<TargetFramework Condition="$(TargetFramework) == ''">$(DotNetCoreFrameworkVersion)</TargetFramework>-->
     <IsDjvuNetTestProject>false</IsDjvuNetTestProject>


### PR DESCRIPTION
This PR brings two sets of changes:

1. Improvement of build script with the addition of fine-grained control over which parts of build processes are executed: DjvuNet library build, tests build, tests run.

2. Reverting "Remove .NET Framework support" due to Visual Studio 2019 bug which kills VS support for DjvuNet - see [VS 2019 v16.3.4 and v16.4.prev2 are unable to build netcoreapp3.0 projects which use custom MSBuild tools targeting netcoreapp3.0](https://github.com/dotnet/project-system/issues/5590)